### PR TITLE
feat: add shared CI workflows, Claude Code integrations, and git hooks

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -1,4 +1,4 @@
-name: CI (Node.js)
+name: CI - Node.js
 
 on:
   workflow_call:
@@ -14,14 +14,23 @@ on:
         type: string
         default: 'npm test'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
+
       - run: npm ci
-      - run: ${{ inputs.test-command }}
+
+      - name: Run tests
+        env:
+          TEST_CMD: ${{ inputs.test-command }}
+        run: $TEST_CMD

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,0 +1,35 @@
+name: CI - Rust
+
+on:
+  workflow_call:
+    inputs:
+      rust-version:
+        description: 'Rust toolchain version'
+        required: false
+        type: string
+        default: 'stable'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@a54c7afe936401765a5605df8a934cdeb93a31be
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+
+      - name: Format check
+        run: cargo fmt --check --all
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# .github
+
+Shared CI workflows, workflow templates, and scripts for the agent-sh organization.
+
+## Reusable Workflows
+
+Located in `.github/workflows/`, these are called via `workflow_call` from individual repos.
+
+### ci-node.yml
+
+Reusable Node.js CI workflow. Steps: checkout, setup Node, `npm ci`, run tests.
+
+**Inputs:**
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `node-version` | `20` | Node.js version |
+| `test-command` | `npm test` | Test command to run |
+
+**Caller example:**
+
+```yaml
+jobs:
+  ci:
+    uses: agent-sh/.github/.github/workflows/ci-node.yml@main
+```
+
+### ci-rust.yml
+
+Reusable Rust CI workflow. Steps: checkout, install toolchain, `cargo fmt --check`, `cargo clippy`, `cargo test`.
+
+**Inputs:**
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `rust-version` | `stable` | Rust toolchain version |
+
+**Caller example:**
+
+```yaml
+jobs:
+  ci:
+    uses: agent-sh/.github/.github/workflows/ci-rust.yml@main
+```
+
+## Workflow Templates
+
+Located in `workflow-templates/`, these are available in the GitHub "New workflow" UI for org repos.
+
+| Template | Description |
+|----------|-------------|
+| `ci-node.yml` | Thin caller for the reusable Node.js CI workflow |
+| `ci-rust.yml` | Thin caller for the reusable Rust CI workflow |
+| `claude-code-review.yml` | Automated PR review via Claude Code (owner/member/collaborator, max 3 runs per PR) |
+| `claude-mentions.yml` | Respond to @claude mentions in issues and PRs |
+
+## Scripts
+
+### setup-hooks.sh
+
+Detects project type (Node.js or Rust) and installs the appropriate pre-push git hook.
+
+```bash
+sh scripts/setup-hooks.sh
+```
+
+### rollout.sh
+
+Rolls out CI workflows, Claude Code integrations, and hooks to all agent-sh repos by creating PRs.
+
+```bash
+sh scripts/rollout.sh            # Create PRs
+sh scripts/rollout.sh --dry-run  # Preview changes
+```
+
+## Required Org Secrets
+
+| Secret | Used By | Purpose |
+|--------|---------|---------|
+| `CLAUDE_CODE_OAUTH_TOKEN` | claude-code-review, claude-mentions | Authentication for Claude Code Action |
+
+## Adoption
+
+For new repos, either:
+
+1. Use the workflow templates from the GitHub UI ("Actions" > "New workflow")
+2. Run `sh scripts/rollout.sh` to bulk-add to all repos
+3. Manually copy the caller workflow and scripts
+
+After adding workflows, install the git hook locally:
+
+```bash
+sh scripts/setup-hooks.sh
+```

--- a/scripts/pre-push-node
+++ b/scripts/pre-push-node
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Pre-push hook for Node.js projects
+# Runs tests before allowing push
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+echo "[INFO] Running pre-push tests..."
+npm test
+exit $?

--- a/scripts/pre-push-rust
+++ b/scripts/pre-push-rust
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Pre-push hook for Rust projects
+# Runs clippy and tests before allowing push
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+echo "[INFO] Running pre-push checks..."
+cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace
+exit $?

--- a/scripts/rollout.sh
+++ b/scripts/rollout.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# Rollout CI workflows, Claude Code integrations, and hooks to all agent-sh repos
+#
+# Usage:
+#   sh scripts/rollout.sh            # Create PRs in all repos
+#   sh scripts/rollout.sh --dry-run  # Show what would happen without making changes
+
+DRY_RUN=false
+if [ "$1" = "--dry-run" ]; then
+  DRY_RUN=true
+  echo "[INFO] Dry run mode - no changes will be made"
+fi
+
+# Verify gh CLI is available and authenticated
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[ERROR] gh CLI not found - install from https://cli.github.com"
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "[ERROR] gh CLI not authenticated - run 'gh auth login'"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ORG_GITHUB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BRANCH="add-ci-workflows"
+
+# All org repos to roll out to
+NODE_REPOS="web-ctl next-task deslop ship perf audit-project sync-docs repo-map drift-detect debate consult learn enhance agent-core agent-knowledge agent-sh.dev"
+RUST_REPOS="agnix"
+
+# Validate source files exist before starting
+MISSING=""
+for f in \
+  "$ORG_GITHUB_DIR/workflow-templates/ci-node.yml" \
+  "$ORG_GITHUB_DIR/workflow-templates/ci-rust.yml" \
+  "$ORG_GITHUB_DIR/workflow-templates/claude-code-review.yml" \
+  "$ORG_GITHUB_DIR/workflow-templates/claude-mentions.yml" \
+  "$ORG_GITHUB_DIR/scripts/setup-hooks.sh" \
+  "$ORG_GITHUB_DIR/scripts/pre-push-node" \
+  "$ORG_GITHUB_DIR/scripts/pre-push-rust"; do
+  if [ ! -f "$f" ]; then
+    echo "[ERROR] Missing source file: $f"
+    MISSING="yes"
+  fi
+done
+if [ "$MISSING" = "yes" ]; then
+  echo "[ERROR] Cannot proceed - missing source files"
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+rollout_repo() {
+  REPO="$1"
+  REPO_TYPE="$2"
+
+  echo ""
+  echo "--- $REPO ($REPO_TYPE) ---"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[DRY-RUN] Would clone agent-sh/$REPO"
+    echo "[DRY-RUN] Would add ci-${REPO_TYPE}.yml as .github/workflows/ci.yml"
+    echo "[DRY-RUN] Would add claude-code-review.yml"
+    echo "[DRY-RUN] Would add claude-mentions.yml (as claude.yml)"
+    echo "[DRY-RUN] Would add scripts/setup-hooks.sh and pre-push hook"
+    echo "[DRY-RUN] Would create PR"
+    return
+  fi
+
+  CLONE_DIR="$WORK_DIR/$REPO"
+
+  # Clone
+  if ! gh repo clone "agent-sh/$REPO" "$CLONE_DIR" -- --depth 1 2>/dev/null; then
+    echo "[ERROR] Failed to clone agent-sh/$REPO - skipping"
+    return
+  fi
+
+  # Run in subshell to isolate working directory changes
+  (
+    cd "$CLONE_DIR"
+
+    # Check if branch already exists on remote
+    if git ls-remote --heads origin "$BRANCH" | grep -qF "refs/heads/$BRANCH"; then
+      echo "[WARN] Branch $BRANCH already exists on agent-sh/$REPO - skipping"
+      exit 0
+    fi
+
+    git checkout -b "$BRANCH"
+
+    # CI workflow
+    mkdir -p .github/workflows
+    if [ "$REPO_TYPE" = "rust" ]; then
+      cp "$ORG_GITHUB_DIR/workflow-templates/ci-rust.yml" .github/workflows/ci.yml
+    else
+      cp "$ORG_GITHUB_DIR/workflow-templates/ci-node.yml" .github/workflows/ci.yml
+    fi
+
+    # Claude Code workflows
+    cp "$ORG_GITHUB_DIR/workflow-templates/claude-code-review.yml" .github/workflows/claude-code-review.yml
+    cp "$ORG_GITHUB_DIR/workflow-templates/claude-mentions.yml" .github/workflows/claude.yml
+
+    # Hook scripts
+    mkdir -p scripts
+    cp "$ORG_GITHUB_DIR/scripts/setup-hooks.sh" scripts/setup-hooks.sh
+    if [ "$REPO_TYPE" = "rust" ]; then
+      cp "$ORG_GITHUB_DIR/scripts/pre-push-rust" scripts/pre-push-rust
+    else
+      cp "$ORG_GITHUB_DIR/scripts/pre-push-node" scripts/pre-push-node
+    fi
+    chmod +x scripts/setup-hooks.sh scripts/pre-push-*
+
+    # Commit and push - stage only specific files
+    git add .github/workflows/ scripts/
+    git commit -m "$(cat <<'EOF'
+ci: add shared CI workflows, Claude Code review, and git hooks
+
+- CI workflow calling reusable workflow from agent-sh/.github
+- Claude Code automated PR review (owner/member/collaborator only, max 3 runs)
+- Claude Code @mentions support
+- Pre-push hook running tests before push
+EOF
+)"
+
+    git push -u origin "$BRANCH"
+
+    # Create PR
+    gh pr create \
+      --repo "agent-sh/$REPO" \
+      --title "ci: add shared CI workflows and hooks" \
+      --body "$(cat <<'EOF'
+## Summary
+
+- Adds CI workflow (reusable from agent-sh/.github)
+- Adds Claude Code automated PR review
+- Adds Claude Code @mentions workflow
+- Adds pre-push git hook (run `sh scripts/setup-hooks.sh` to install)
+
+## Required Org Secrets
+
+- `CLAUDE_CODE_OAUTH_TOKEN` - for Claude Code Action
+
+## Test Plan
+
+- [ ] CI workflow runs on PR
+- [ ] Claude Code review triggers on PR open
+- [ ] @claude mentions work in issues/PRs
+- [ ] `sh scripts/setup-hooks.sh` installs pre-push hook
+EOF
+)"
+
+    echo "[OK] PR created for agent-sh/$REPO"
+  )
+
+  if [ $? -ne 0 ]; then
+    echo "[ERROR] Rollout failed for agent-sh/$REPO - continuing with next repo"
+  fi
+}
+
+# Roll out to Node repos
+for repo in $NODE_REPOS; do
+  rollout_repo "$repo" "node"
+done
+
+# Roll out to Rust repos
+for repo in $RUST_REPOS; do
+  rollout_repo "$repo" "rust"
+done
+
+echo ""
+echo "[OK] Rollout complete"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Setup git hooks for agent-sh repos
+# Detects project type and installs the appropriate pre-push hook
+#
+# Usage: sh scripts/setup-hooks.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Verify we are inside a git repository
+if ! git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[ERROR] Not a git repository: $REPO_ROOT"
+  exit 1
+fi
+
+# Resolve hooks directory (handles worktrees where .git is a file)
+if [ -f "$REPO_ROOT/.git" ]; then
+  COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir)"
+  HOOKS_DIR="$COMMON_DIR/hooks"
+else
+  HOOKS_DIR="$REPO_ROOT/.git/hooks"
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+# Detect project type and install hook
+if [ -f "$REPO_ROOT/Cargo.toml" ]; then
+  echo "[INFO] Detected Rust project"
+  if [ ! -f "$SCRIPT_DIR/pre-push-rust" ]; then
+    echo "[ERROR] Missing hook script: $SCRIPT_DIR/pre-push-rust"
+    exit 1
+  fi
+  cp "$SCRIPT_DIR/pre-push-rust" "$HOOKS_DIR/pre-push"
+  chmod +x "$HOOKS_DIR/pre-push"
+  echo "[OK] Installed pre-push hook (Rust)"
+elif [ -f "$REPO_ROOT/package.json" ]; then
+  echo "[INFO] Detected Node.js project"
+  if [ ! -f "$SCRIPT_DIR/pre-push-node" ]; then
+    echo "[ERROR] Missing hook script: $SCRIPT_DIR/pre-push-node"
+    exit 1
+  fi
+  cp "$SCRIPT_DIR/pre-push-node" "$HOOKS_DIR/pre-push"
+  chmod +x "$HOOKS_DIR/pre-push"
+  echo "[OK] Installed pre-push hook (Node.js)"
+else
+  echo "[WARN] No package.json or Cargo.toml found - skipping hook install"
+  exit 0
+fi

--- a/workflow-templates/ci-node.properties.json
+++ b/workflow-templates/ci-node.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "CI - Node.js",
+  "description": "Node.js CI workflow for agent-sh plugin repos",
+  "iconName": "nodejs",
+  "categories": ["Node.js", "CI"]
+}

--- a/workflow-templates/ci-node.yml
+++ b/workflow-templates/ci-node.yml
@@ -1,0 +1,12 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: agent-sh/.github/.github/workflows/ci-node.yml@main
+    secrets: inherit

--- a/workflow-templates/ci-rust.properties.json
+++ b/workflow-templates/ci-rust.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "CI - Rust",
+  "description": "Rust CI workflow for agent-sh repos",
+  "iconName": "rust",
+  "categories": ["Rust", "CI"]
+}

--- a/workflow-templates/ci-rust.yml
+++ b/workflow-templates/ci-rust.yml
@@ -1,0 +1,12 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: agent-sh/.github/.github/workflows/ci-rust.yml@main
+    secrets: inherit

--- a/workflow-templates/claude-code-review.properties.json
+++ b/workflow-templates/claude-code-review.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Claude Code - Automated PR Review",
+  "description": "Automated PR review using Claude Code for agent-sh repos",
+  "iconName": "cloud",
+  "categories": ["CI", "Review"]
+}

--- a/workflow-templates/claude-code-review.yml
+++ b/workflow-templates/claude-code-review.yml
@@ -1,0 +1,77 @@
+name: Claude Code - Automated PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    if: >-
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+      github.event.pull_request.author_association)
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check run count
+        id: check-runs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          WORKFLOW_FILE="claude-code-review.yml"
+
+          RUN_COUNT=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&status=completed" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request")] | length' || echo "")
+
+          RUN_COUNT=${RUN_COUNT:-0}
+          if ! echo "$RUN_COUNT" | grep -qE '^[0-9]+$'; then
+            echo "[WARN] Invalid RUN_COUNT value ('$RUN_COUNT') from GitHub API. Defaulting to 0."
+            RUN_COUNT=0
+          fi
+
+          RUN_COUNT=$((RUN_COUNT + 1))
+
+          echo "This is run #$RUN_COUNT for this PR (event: $EVENT_ACTION)"
+
+          if [ "$RUN_COUNT" -le 3 ]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "[OK] Will run Claude review (run $RUN_COUNT of 3)"
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "[SKIP] Skipping Claude review (already ran 3 times)"
+          fi
+
+      - name: Run Claude Code Review
+        if: steps.check-runs.outputs.should_run == 'true'
+        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          use_commit_signing: true
+
+      - name: Comment on PR (skipped)
+        if: steps.check-runs.outputs.should_run == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this PR."

--- a/workflow-templates/claude-mentions.properties.json
+++ b/workflow-templates/claude-mentions.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Claude Code - @mentions",
+  "description": "Respond to @claude mentions in issues and PRs for agent-sh repos",
+  "iconName": "cloud",
+  "categories": ["CI", "Automation"]
+}

--- a/workflow-templates/claude-mentions.yml
+++ b/workflow-templates/claude-mentions.yml
@@ -1,0 +1,57 @@
+name: Claude Code - @mentions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened]
+
+jobs:
+  claude-mention:
+    if: |
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-opus-4-6
+          use_commit_signing: true


### PR DESCRIPTION
## Summary

- Enhances reusable Node.js CI workflow with pinned action SHAs, permissions, and injection prevention
- Adds reusable Rust CI workflow with fmt, clippy, test, and Swatinem/rust-cache
- Adds workflow templates for Claude Code PR review and @claude mentions
- Adds shared pre-push hook setup and batch rollout script for all 17 repos

## Changes

**Reusable workflows** (`.github/workflows/`):
- `ci-node.yml` - enhanced with pinned SHAs, explicit permissions, env var for test-command
- `ci-rust.yml` - new: fmt check, clippy (all-features), test, rust-cache

**Workflow templates** (`workflow-templates/`):
- `ci-node.yml` / `ci-rust.yml` - thin callers with `secrets: inherit`
- `claude-code-review.yml` - automated PR review (owner/member/collaborator, max 3 runs)
- `claude-mentions.yml` - @claude mentions handler with github_token

**Scripts** (`scripts/`):
- `setup-hooks.sh` - auto-detect Node/Rust, install pre-push hook (worktree-aware)
- `rollout.sh` - batch deploy to 17 repos with `--dry-run`, gh CLI validation, subshell isolation
- `pre-push-node` / `pre-push-rust` - hook implementations

## Security

- All action versions pinned with SHA comments
- Expression injection prevented via env vars (not direct interpolation)
- Removed unnecessary `id-token: write` permission
- Author check covers OWNER/MEMBER/COLLABORATOR

## Required Org Secrets

- `CLAUDE_CODE_OAUTH_TOKEN` - for Claude Code Action

## Test Plan

- [x] All YAML files parse correctly
- [x] All shell scripts pass `sh -n` syntax check
- [x] Rollout script dry-run validates correctly
- [x] Action versions pinned with SHA
- [ ] CI workflow runs on this PR
- [ ] Claude Code review triggers

Closes #1