### PR TITLE
fix: handle repos without package-lock.json in CI

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -26,9 +26,14 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: 'npm'
 
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          elif [ -f package.json ]; then
+            npm install --no-save
+          fi
 
       - name: Run tests
         env:


### PR DESCRIPTION
Removes cache:npm from setup-node and falls back to npm install when no package-lock.json present. Fixes CI failures in all 16 Node plugin repos.