### PR TITLE
fix: remove --all-features from clippy to match agnix CI

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo fmt --check --all
 
       - name: Clippy
-        run: cargo clippy --workspace --all-features -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Test
         run: cargo test --workspace

--- a/scripts/pre-push-rust
+++ b/scripts/pre-push-rust
@@ -5,5 +5,5 @@
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 echo "[INFO] Running pre-push checks..."
-cargo clippy --workspace --all-features -- -D warnings && cargo test --workspace
+cargo clippy --workspace -- -D warnings && cargo test --workspace
 exit $?


### PR DESCRIPTION
Agnix CI runs clippy without --all-features. Our reusable workflow added it, causing failures on feature-gated code. Match the existing behavior.