### PR TITLE
ci: add reusable agnix validation workflow

### DIFF
--- a/.github/workflows/ci-agnix.yml
+++ b/.github/workflows/ci-agnix.yml
@@ -1,0 +1,19 @@
+name: CI - agnix
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  agnix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate agent configurations
+        uses: agent-sh/agnix@v0.16.1
+        with:
+          config: '.agnix.toml'
+          fail-on-error: 'true'


### PR DESCRIPTION
## Summary

- Add `ci-agnix.yml` reusable workflow that runs the agnix GitHub Action (v0.16.1)
- Validates agent configurations (CLAUDE.md, AGENTS.md, skills, hooks, MCP, plugins) using each repo's `.agnix.toml` config
- Other repos call this via `uses: agent-sh/.github/.github/workflows/ci-agnix.yml@main`

## Test plan

- [ ] Verify workflow syntax is valid (GitHub will validate on push)
- [ ] Confirm dependent repo PRs can reference this workflow after merge